### PR TITLE
Added missing slot for apex_legends VertexLitBump

### DIFF
--- a/bsp_tool/branches/respawn/apex_legends.py
+++ b/bsp_tool/branches/respawn/apex_legends.py
@@ -347,7 +347,7 @@ class VertexLitBump(base.Struct):  # LUMP 73 (0049)
     negative_one: int  # -1
     uv1: List[float]  # lightmap coords
     colour: List[int]
-    __slots__ = ["position_index", "normal_index", "uv0", "negative_one", "uv1"]
+    __slots__ = ["position_index", "normal_index", "uv0", "negative_one", "uv1", "colour"]
     _format = "2I2fi2f4B"  # 32 bytes
     _arrays = {"uv0": [*"uv"], "uv1": [*"uv"], "colour": [*"rgba"]}
 


### PR DESCRIPTION
caused an issue with lump_as_bytes where it would try to pack more items than were available:
`struct.error: pack expected 11 items for packing (got 7)`